### PR TITLE
Ensure tags are always an array

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export const OpenLyricsParser = (fileContent: string): IParserRoot => {
     'song.lyrics.verse.lines',
     'song.lyrics.instrument',
     'song.lyrics.instrument.lines',
+    'song.format.tags.tag',
   ];
 
   const xmlParser = new XMLParser({


### PR DESCRIPTION
Fixes https://github.com/ChrisMBarr/OpenLyrics-parser/issues/59 by supporting cases where we have only one `<tag>`.